### PR TITLE
fix tests

### DIFF
--- a/bin/topk-hk/main.go
+++ b/bin/topk-hk/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/migotom/heavykeeper"
 )
@@ -32,7 +34,9 @@ func main() {
 		}
 	}
 
-	heavykeeper := heavykeeper.New(4, uint32(*k), uint32(*width), uint32(*depth), *decay)
+	rand.Seed(time.Now().UnixNano())
+
+	heavykeeper := heavykeeper.New(4, uint32(*k), uint32(*width), uint32(*depth), *decay, rand.Int())
 
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/pkg/minheap/min_heap_test.go
+++ b/pkg/minheap/min_heap_test.go
@@ -15,26 +15,26 @@ func TestAdd(t *testing.T) {
 		{
 			Name:       "A1,B2",
 			K:          2,
-			NodesToAdd: Nodes{Node{Item: "A", Count: 1}, Node{Item: "B", Count: 2}},
-			Expected:   Nodes{Node{Item: "A", Count: 1}, Node{Item: "B", Count: 2}},
+			NodesToAdd: Nodes{Node{Item: []byte("A"), Count: 1}, Node{Item: []byte("B"), Count: 2}},
+			Expected:   Nodes{Node{Item: []byte("A"), Count: 1}, Node{Item: []byte("B"), Count: 2}},
 		},
 		{
 			Name:       "A1,B2,C3 (drop lowest A)",
 			K:          2,
-			NodesToAdd: Nodes{Node{Item: "A", Count: 1}, Node{Item: "B", Count: 2}, Node{Item: "C", Count: 3}},
-			Expected:   Nodes{Node{Item: "B", Count: 2}, Node{Item: "C", Count: 3}},
+			NodesToAdd: Nodes{Node{Item: []byte("A"), Count: 1}, Node{Item: []byte("B"), Count: 2}, Node{Item: []byte("C"), Count: 3}},
+			Expected:   Nodes{Node{Item: []byte("B"), Count: 2}, Node{Item: []byte("C"), Count: 3}},
 		},
 		{
 			Name:       "B2,C3,A1 (do not add small A)",
 			K:          2,
-			NodesToAdd: Nodes{Node{Item: "B", Count: 2}, Node{Item: "C", Count: 3}, Node{Item: "A", Count: 1}},
-			Expected:   Nodes{Node{Item: "B", Count: 2}, Node{Item: "C", Count: 3}},
+			NodesToAdd: Nodes{Node{Item: []byte("B"), Count: 2}, Node{Item: []byte("C"), Count: 3}, Node{Item: []byte("A"), Count: 1}},
+			Expected:   Nodes{Node{Item: []byte("B"), Count: 2}, Node{Item: []byte("C"), Count: 3}},
 		},
 		{
 			Name:       "A13,B4,C9,D12,E0,F20 (mixed)",
 			K:          3,
-			NodesToAdd: Nodes{Node{Item: "A", Count: 13}, Node{Item: "B", Count: 4}, Node{Item: "C", Count: 9}, Node{Item: "D", Count: 12}, Node{Item: "E", Count: 0}, Node{Item: "F", Count: 20}},
-			Expected:   Nodes{Node{Item: "D", Count: 12}, Node{Item: "F", Count: 20}, Node{Item: "A", Count: 13}},
+			NodesToAdd: Nodes{Node{Item: []byte("A"), Count: 13}, Node{Item: []byte("B"), Count: 4}, Node{Item: []byte("C"), Count: 9}, Node{Item: []byte("D"), Count: 12}, Node{Item: []byte("E"), Count: 0}, Node{Item: []byte("F"), Count: 20}},
+			Expected:   Nodes{Node{Item: []byte("D"), Count: 12}, Node{Item: []byte("F"), Count: 20}, Node{Item: []byte("A"), Count: 13}},
 		},
 	}
 	for _, tc := range cases {
@@ -54,8 +54,8 @@ func TestAdd(t *testing.T) {
 
 func TestFix(t *testing.T) {
 	minheap := NewHeap(2)
-	minheap.Add(Node{Item: "A", Count: 1})
-	minheap.Add(Node{Item: "B", Count: 2})
+	minheap.Add(Node{Item: []byte("A"), Count: 1})
+	minheap.Add(Node{Item: []byte("B"), Count: 2})
 
 	minheap.Fix(0, 10)
 
@@ -70,10 +70,10 @@ func TestMin(t *testing.T) {
 		t.Errorf("not expected state after min-heap min operation %v, expected %v", minheap.Min(), 0)
 	}
 
-	minheap.Add(Node{Item: "A", Count: 1})
-	minheap.Add(Node{Item: "B", Count: 2})
-	minheap.Add(Node{Item: "C", Count: 0})
-	minheap.Add(Node{Item: "D", Count: 6})
+	minheap.Add(Node{Item: []byte("A"), Count: 1})
+	minheap.Add(Node{Item: []byte("B"), Count: 2})
+	minheap.Add(Node{Item: []byte("C"), Count: 0})
+	minheap.Add(Node{Item: []byte("D"), Count: 6})
 
 	if minheap.Min() == 0 {
 		t.Errorf("not expected state after min-heap min operation %v, expected %v", minheap.Min(), 0)
@@ -82,16 +82,16 @@ func TestMin(t *testing.T) {
 
 func TestFind(t *testing.T) {
 	minheap := NewHeap(3)
-	minheap.Add(Node{Item: "A", Count: 1})
-	minheap.Add(Node{Item: "B", Count: 2})
-	minheap.Add(Node{Item: "C", Count: 3})
+	minheap.Add(Node{Item: []byte("A"), Count: 1})
+	minheap.Add(Node{Item: []byte("B"), Count: 2})
+	minheap.Add(Node{Item: []byte("C"), Count: 3})
 
-	position, found := minheap.Find("B")
+	position, found := minheap.Find([]byte("B"))
 	if !found || position != 1 {
 		t.Errorf("not expected state after min-heap find operation position=%v, found=%v, expected to find position 1", position, found)
 	}
 
-	position, found = minheap.Find("X")
+	position, found = minheap.Find([]byte("X"))
 	if found || position != 0 {
 		t.Errorf("not expected state after min-heap find operation position=%v, found=%v, expected to not find anything", position, found)
 	}
@@ -99,13 +99,13 @@ func TestFind(t *testing.T) {
 
 func TestSorted(t *testing.T) {
 	minheap := NewHeap(3)
-	minheap.Add(Node{Item: "A", Count: 4})
-	minheap.Add(Node{Item: "B", Count: 2})
-	minheap.Add(Node{Item: "C", Count: 9})
-	minheap.Add(Node{Item: "D", Count: 1})
+	minheap.Add(Node{Item: []byte("A"), Count: 4})
+	minheap.Add(Node{Item: []byte("B"), Count: 2})
+	minheap.Add(Node{Item: []byte("C"), Count: 9})
+	minheap.Add(Node{Item: []byte("D"), Count: 1})
 
 	nodes := minheap.Sorted()
-	expected := Nodes{Node{Item: "C", Count: 9}, Node{Item: "A", Count: 4}, Node{Item: "B", Count: 2}}
+	expected := Nodes{Node{Item: []byte("C"), Count: 9}, Node{Item: []byte("A"), Count: 4}, Node{Item: []byte("B"), Count: 2}}
 	if !reflect.DeepEqual(nodes, expected) {
 		t.Errorf("not expected state after min-heap Sorted operation %v, expected %v", nodes, expected)
 	}


### PR DESCRIPTION
I missed a couple tests in https://github.com/migotom/heavykeeper/pull/1, they should be fixed here.

```
$ go test -v ./...
=== RUN   TestAdd
=== RUN   TestAdd/uniform_stream
=== RUN   TestAdd/mixed_stream
=== RUN   TestAdd/dominated_by_one_value_stream
=== RUN   TestAdd/dominated_by_two_values_streams
=== RUN   TestAdd/Tolstoy's_"War_and_Peace"_stream
--- PASS: TestAdd (0.46s)
    --- PASS: TestAdd/uniform_stream (0.00s)
    --- PASS: TestAdd/mixed_stream (0.00s)
    --- PASS: TestAdd/dominated_by_one_value_stream (0.00s)
    --- PASS: TestAdd/dominated_by_two_values_streams (0.00s)
    --- PASS: TestAdd/Tolstoy's_"War_and_Peace"_stream (0.42s)
PASS
ok  	github.com/migotom/heavykeeper	(cached)
?   	github.com/migotom/heavykeeper/bin/topk-hk	[no test files]
=== RUN   TestAdd
=== RUN   TestAdd/A1,B2
=== RUN   TestAdd/A1,B2,C3_(drop_lowest_A)
=== RUN   TestAdd/B2,C3,A1_(do_not_add_small_A)
=== RUN   TestAdd/A13,B4,C9,D12,E0,F20_(mixed)
--- PASS: TestAdd (0.00s)
    --- PASS: TestAdd/A1,B2 (0.00s)
    --- PASS: TestAdd/A1,B2,C3_(drop_lowest_A) (0.00s)
    --- PASS: TestAdd/B2,C3,A1_(do_not_add_small_A) (0.00s)
    --- PASS: TestAdd/A13,B4,C9,D12,E0,F20_(mixed) (0.00s)
=== RUN   TestFix
--- PASS: TestFix (0.00s)
=== RUN   TestMin
--- PASS: TestMin (0.00s)
=== RUN   TestFind
--- PASS: TestFind (0.00s)
=== RUN   TestSorted
--- PASS: TestSorted (0.00s)
=== RUN   TestNodesLen
=== RUN   TestNodesLen/Empty
=== RUN   TestNodesLen/Two
--- PASS: TestNodesLen (0.00s)
    --- PASS: TestNodesLen/Empty (0.00s)
    --- PASS: TestNodesLen/Two (0.00s)
=== RUN   TestNodesLess
=== RUN   TestNodesLess/A>B
=== RUN   TestNodesLess/1<2
=== RUN   TestNodesLess/in_middle_10<20
--- PASS: TestNodesLess (0.00s)
    --- PASS: TestNodesLess/A>B (0.00s)
    --- PASS: TestNodesLess/1<2 (0.00s)
    --- PASS: TestNodesLess/in_middle_10<20 (0.00s)
=== RUN   TestNodesSwap
=== RUN   TestNodesSwap/A<->B
--- PASS: TestNodesSwap (0.00s)
    --- PASS: TestNodesSwap/A<->B (0.00s)
=== RUN   TestNodesPush
=== RUN   TestNodesPush/add_A_to_empty
=== RUN   TestNodesPush/add_B
=== RUN   TestNodesPush/add_C
--- PASS: TestNodesPush (0.00s)
    --- PASS: TestNodesPush/add_A_to_empty (0.00s)
    --- PASS: TestNodesPush/add_B (0.00s)
    --- PASS: TestNodesPush/add_C (0.00s)
=== RUN   TestNodesPop
=== RUN   TestNodesPop/pop_from_{A,B}
--- PASS: TestNodesPop (0.00s)
    --- PASS: TestNodesPop/pop_from_{A,B} (0.00s)
PASS
ok  	github.com/migotom/heavykeeper/pkg/minheap	(cached)
```